### PR TITLE
Add whisper.cpp transcription support with fallback

### DIFF
--- a/ai-secretary-app/.env.local.example
+++ b/ai-secretary-app/.env.local.example
@@ -1,3 +1,12 @@
+# Optional local whisper.cpp configuration (uncomment to enable)
+# WHISPER_CPP_BINARY=/opt/whisper.cpp/main
+# WHISPER_CPP_MODEL=/opt/whisper.cpp/models/ggml-base.bin
+# WHISPER_CPP_LANGUAGE=ru
+# WHISPER_CPP_THREADS=4
+# WHISPER_CPP_TIMEOUT_MS=300000
+# WHISPER_CPP_ENABLED=true
+# WHISPER_CPP_FALLBACK_ON_ERROR=true
+
 # OpenAI Whisper API key
 OPENAI_API_KEY=sk-...
 OPENAI_REQUEST_TIMEOUT_MS=90000

--- a/ai-secretary-app/app/api/whisper/route.ts
+++ b/ai-secretary-app/app/api/whisper/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { transcribeFileWithWhisper } from "@/lib/openai";
+import { transcribeAudioFile } from "@/lib/transcription";
 import { WHISPER_MAX_FILE_SIZE_BYTES } from "@/lib/constants";
 
 export const runtime = "nodejs";
@@ -22,12 +22,12 @@ export async function POST(request: Request): Promise<NextResponse> {
   }
 
   try {
-    const transcript = await transcribeFileWithWhisper(file);
+    const transcript = await transcribeAudioFile(file);
     return NextResponse.json({ transcript });
   } catch (error) {
     console.error("Whisper transcription failed", error);
     return NextResponse.json(
-      { detail: "Ошибка при обращении к OpenAI Whisper API" },
+      { detail: "Ошибка при обработке аудио (Whisper)" },
       { status: 502 },
     );
   }

--- a/ai-secretary-app/lib/openai.ts
+++ b/ai-secretary-app/lib/openai.ts
@@ -19,7 +19,7 @@ function getClient(): OpenAI {
   return client;
 }
 
-export async function transcribeFileWithWhisper(file: File): Promise<string> {
+export async function transcribeFileWithOpenAI(file: File): Promise<string> {
   const openai = getClient();
   const buffer = Buffer.from(await file.arrayBuffer());
   const preparedFile = await toFile(buffer, file.name || "meeting-audio", {

--- a/ai-secretary-app/lib/transcription.ts
+++ b/ai-secretary-app/lib/transcription.ts
@@ -1,0 +1,186 @@
+import { Buffer } from "node:buffer";
+import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { transcribeFileWithOpenAI } from "@/lib/openai";
+
+const whisperCppBinary = process.env.WHISPER_CPP_BINARY;
+const whisperCppModel = process.env.WHISPER_CPP_MODEL;
+const whisperCppLanguage = process.env.WHISPER_CPP_LANGUAGE;
+const whisperCppThreads = parsePositiveInteger(process.env.WHISPER_CPP_THREADS);
+const whisperCppEnabled = parseBoolean(process.env.WHISPER_CPP_ENABLED, true);
+const whisperCppFallbackOnError = parseBoolean(
+  process.env.WHISPER_CPP_FALLBACK_ON_ERROR,
+  true,
+);
+const whisperCppTimeoutMs = parseTimeout(process.env.WHISPER_CPP_TIMEOUT_MS);
+
+const MAX_STDERR_LOG_LENGTH = 2000;
+
+function parseBoolean(value: string | undefined, defaultValue: boolean): boolean {
+  if (value === undefined) {
+    return defaultValue;
+  }
+  const normalized = value.trim().toLowerCase();
+  return !["false", "0", "no"].includes(normalized);
+}
+
+function parsePositiveInteger(value: string | undefined): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function parseTimeout(value: string | undefined): number | undefined {
+  if (!value) {
+    return 300_000; // 5 minutes by default
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function isWhisperCppAvailable(): boolean {
+  return Boolean(whisperCppEnabled && whisperCppBinary && whisperCppModel);
+}
+
+function getFileExtension(name: string | undefined): string {
+  if (!name) {
+    return "";
+  }
+  const lastDot = name.lastIndexOf(".");
+  if (lastDot === -1) {
+    return "";
+  }
+  return name.slice(lastDot);
+}
+
+async function runWhisperCpp(binary: string, args: string[], timeoutMs?: number): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(binary, args, { stdio: ["ignore", "pipe", "pipe"] });
+    let stderrBuffer = "";
+    let completed = false;
+    let timeoutHandle: NodeJS.Timeout | null = null;
+
+    const cleanup = () => {
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle);
+        timeoutHandle = null;
+      }
+    };
+
+    const rejectOnce = (error: Error) => {
+      if (completed) {
+        return;
+      }
+      completed = true;
+      cleanup();
+      reject(error);
+    };
+
+    child.stderr?.setEncoding("utf8");
+    child.stderr?.on("data", (chunk: string) => {
+      stderrBuffer = `${stderrBuffer}${chunk}`;
+      if (stderrBuffer.length > MAX_STDERR_LOG_LENGTH) {
+        stderrBuffer = stderrBuffer.slice(-MAX_STDERR_LOG_LENGTH);
+      }
+    });
+
+    child.on("error", (error) => {
+      rejectOnce(new Error(`Failed to start whisper.cpp binary: ${error.message}`));
+    });
+
+    child.on("close", (code) => {
+      if (completed) {
+        return;
+      }
+      completed = true;
+      cleanup();
+      if (code === 0) {
+        resolve();
+      } else {
+        const trimmedStderr = stderrBuffer.trim();
+        const details = trimmedStderr ? `: ${trimmedStderr}` : "";
+        reject(new Error(`whisper.cpp exited with code ${code}${details}`));
+      }
+    });
+
+    if (timeoutMs && timeoutMs > 0) {
+      timeoutHandle = setTimeout(() => {
+        child.kill("SIGKILL");
+        rejectOnce(new Error(`whisper.cpp timed out after ${timeoutMs} ms`));
+      }, timeoutMs);
+    }
+  });
+}
+
+async function transcribeFileWithWhisperCpp(file: File): Promise<string> {
+  if (!whisperCppBinary || !whisperCppModel) {
+    throw new Error("whisper.cpp binary or model path is not configured");
+  }
+
+  const tempDir = await mkdtemp(join(tmpdir(), "whisper-"));
+  const extension = getFileExtension(file.name);
+  const inputFileName = `${randomUUID()}${extension || ".tmp"}`;
+  const inputFilePath = join(tempDir, inputFileName);
+  const outputBasePath = join(tempDir, "transcript");
+
+  try {
+    const buffer = Buffer.from(await file.arrayBuffer());
+    await writeFile(inputFilePath, buffer);
+
+    const args = ["-m", whisperCppModel, "-f", inputFilePath, "-otxt", "-of", outputBasePath];
+    if (whisperCppLanguage) {
+      args.push("-l", whisperCppLanguage);
+    }
+    if (whisperCppThreads !== undefined) {
+      args.push("-t", String(whisperCppThreads));
+    }
+
+    await runWhisperCpp(whisperCppBinary, args, whisperCppTimeoutMs);
+
+    const transcriptPath = `${outputBasePath}.txt`;
+    const transcriptRaw = await readFile(transcriptPath, "utf8");
+    const transcript = transcriptRaw.replace(/\r?\n/g, "\n").trim();
+    if (!transcript) {
+      throw new Error("whisper.cpp produced an empty transcription");
+    }
+    return transcript;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown whisper.cpp error";
+    throw new Error(`whisper.cpp transcription failed: ${message}`);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+export async function transcribeAudioFile(file: File): Promise<string> {
+  if (isWhisperCppAvailable()) {
+    try {
+      return await transcribeFileWithWhisperCpp(file);
+    } catch (error) {
+      console.error("Whisper.cpp transcription failed", error);
+      if (!whisperCppFallbackOnError) {
+        throw error instanceof Error ? error : new Error("Whisper.cpp transcription failed");
+      }
+      console.warn("Falling back to OpenAI Whisper API");
+      try {
+        return await transcribeFileWithOpenAI(file);
+      } catch (fallbackError) {
+        console.error("Fallback to OpenAI Whisper API failed", fallbackError);
+        const primaryMessage = error instanceof Error ? error.message : "Unknown whisper.cpp error";
+        const fallbackMessage =
+          fallbackError instanceof Error ? fallbackError.message : "Unknown OpenAI error";
+        throw new Error(
+          `Whisper.cpp transcription failed (${primaryMessage}) and fallback to OpenAI Whisper API failed (${fallbackMessage})`,
+        );
+      }
+    }
+  }
+
+  return transcribeFileWithOpenAI(file);
+}

--- a/ai-secretary-app/tsconfig.json
+++ b/ai-secretary-app/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "lib": ["dom", "dom.iterable", "es2020"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "es2020"
+    ],
     "allowJs": false,
     "skipLibCheck": true,
     "strict": true,
@@ -15,11 +19,30 @@
     "jsx": "preserve",
     "baseUrl": ".",
     "paths": {
-      "@/components/*": ["components/*"],
-      "@/lib/*": ["lib/*"],
-      "@/hooks/*": ["hooks/*"]
-    }
+      "@/components/*": [
+        "components/*"
+      ],
+      "@/lib/*": [
+        "lib/*"
+      ],
+      "@/hooks/*": [
+        "hooks/*"
+      ]
+    },
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- introduce a transcription helper that prefers a configured `whisper.cpp` binary with OpenAI fallback and timeout handling
- wire the `/api/whisper` route to the new helper and surface a neutral error message
- document the new configuration knobs and sample environment variables for local whisper usage

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc4e0e6944832f88cdd0def313e7e6