### PR TITLE
Validate Jira configuration before creating issues

### DIFF
--- a/ai-secretary-app/components/workflow/JiraIntegrationForm.tsx
+++ b/ai-secretary-app/components/workflow/JiraIntegrationForm.tsx
@@ -21,7 +21,9 @@ export function JiraIntegrationForm({ onSubmit, disabled, defaultBaseUrl }: Jira
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     const { name, value } = event.target;
-    setConfig((prev) => ({ ...prev, [name]: value }));
+    const nextValue =
+      name === "projectKey" ? value.toUpperCase().replace(/\s+/g, "") : value;
+    setConfig((prev) => ({ ...prev, [name]: nextValue }));
   };
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
@@ -94,10 +96,14 @@ export function JiraIntegrationForm({ onSubmit, disabled, defaultBaseUrl }: Jira
             value={config.projectKey}
             onChange={handleChange}
             placeholder="AI"
+            autoCapitalize="characters"
             className="mt-1 w-full rounded-md border border-slate-300 p-2 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
             disabled={disabled}
             required
           />
+          <p className="mt-1 text-xs text-slate-500">
+            Используйте ключ проекта из Jira (обычно состоит из заглавных латинских букв и цифр).
+          </p>
         </div>
         <div className="md:col-span-2">
           <label htmlFor="description" className="block text-sm font-medium text-slate-700">


### PR DESCRIPTION
## Summary
- sanitize and validate Jira configuration on the API route before creating issues
- normalize project keys and improve error messaging when the Jira setup is invalid
- guide users in the Jira integration form by uppercasing the project key input and clarifying the expected format

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc617c56e4832f89bda5745666c968